### PR TITLE
Some modiications in generating erratas and in names of packages.

### DIFF
--- a/errata-template.xml
+++ b/errata-template.xml
@@ -8,7 +8,7 @@
     <collection short="">
       <name>1</name>
       <package arch="noarch" name="%%NAME%%" release="%%REL%%" src="http://www.fedoraproject.org" version="%%VER%%">
-        <filename>%%NAME%%-%%VER%%-%%REL%%.elfake.noarch.rpm</filename>
+        <filename>%%NAME%%-%%VER%%-%%REL%%.noarch.rpm</filename>
       </package>
     </collection>
   </pkglist>

--- a/errata-template.xml
+++ b/errata-template.xml
@@ -1,8 +1,8 @@
-<update from="errata@redhat.com" status="stable" type="security" version="1">
+<update from="errata@redhat.com" status="stable" type="%%TYPE%%" version="1">
   <id>%%ERRATAID%%</id>
   <title>%%NAME%%_Erratum</title>
   <release>%%REL%%</release>
-  <issued date="2012-01-27 16:08:09"/>
+  <issued date="%%DATE%%"/>
   <description>%%NAME%%_Erratum description</description>
   <pkglist>
     <collection short="">

--- a/generate-repo.py
+++ b/generate-repo.py
@@ -155,7 +155,7 @@ if __name__ == '__main__':
 
     description = "Generate a yum repository with fake packages and errata."
 
-    usage = "Usage: %prog [[OUTPUT] [DICTIONARY] [NUMBER] [ERRATAS] [MULTIPLES] [SIZE]]"
+    usage = "Usage: %prog [[OUTPUT] [DICTIONARY] [NUMBER] [MULTIPLES] [SIZE]]"
     epilog = "Constructive comments and feedback can be sent to mmccune at redhat dot com" \
         " and omaciel at ogmaciel dot com."
     version = "%prog version 0.1"

--- a/generate-repo.py
+++ b/generate-repo.py
@@ -19,7 +19,7 @@ def generate_errata(template, last_rev, name, version):
     errata = errata.replace("%%NAME%%", name)
     errata = errata.replace("%%VER%%", version)
     errata = errata.replace("%%TYPE%%", TYPES[random.randint(0,2)])
-    errata = errata.replace("%%DATE%%", datetime.date(2012, random.randint(1,12), random.randint(1,28)).strftime(FORMAT))
+    errata = errata.replace("%%DATE%%", datetime.date(datetime.date.today().year - 1, random.randint(1,12), random.randint(1,28)).strftime(FORMAT))
     return errata
   
   

--- a/generate-repo.py
+++ b/generate-repo.py
@@ -7,6 +7,10 @@ import random
 import os
 import shutil
 from optparse import OptionParser
+import datetime
+
+TYPES = ["security","bugfix","enhancement"]
+FORMAT = "%Y-%m-%d %H:%M:%S"
 
 def generate_errata(template, last_rev, name, version):
     errata = template
@@ -14,6 +18,8 @@ def generate_errata(template, last_rev, name, version):
     errata = errata.replace("%%REL%%", str(last_rev))                
     errata = errata.replace("%%NAME%%", name)
     errata = errata.replace("%%VER%%", version)
+    errata = errata.replace("%%TYPE%%", TYPES[random.randint(0,2)])
+    errata = errata.replace("%%DATE%%", datetime.date(2012, random.randint(1,12), random.randint(1,28)).strftime(FORMAT))
     return errata
   
   
@@ -135,7 +141,7 @@ def generate_repo(output, number, size, multiples, dictionary):
         sys.exit(-1)
 
 
-    os.system("mv ~/rpmbuild/RPMS/noarch/*elfake* %s" % output)
+    os.system("mv ~/rpmbuild/RPMS/noarch/* %s" % output)
     os.system("createrepo %s" % output)
     os.system("modifyrepo %s/updateinfo.xml %s/repodata/" % (output,output))
 
@@ -149,7 +155,7 @@ if __name__ == '__main__':
 
     description = "Generate a yum repository with fake packages and errata."
 
-    usage = "Usage: %prog [[OUTPUT] [DICTIONARY] [NUMBER] [MULTIPLES] [SIZE]]"
+    usage = "Usage: %prog [[OUTPUT] [DICTIONARY] [NUMBER] [ERRATAS] [MULTIPLES] [SIZE]]"
     epilog = "Constructive comments and feedback can be sent to mmccune at redhat dot com" \
         " and omaciel at ogmaciel dot com."
     version = "%prog version 0.1"

--- a/generate-repo.py
+++ b/generate-repo.py
@@ -111,21 +111,21 @@ def generate_repo(output, number, size, multiples, dictionary):
         if multiples:
             # Counter to increment revision version
             last_rev = int(version[-1])
-            # Generate 0-3 newer versions of the package
-            for j in range(random.randint(0,3)):
+            # Generate 1-3 newer versions of the package
+            for j in range(random.randint(1,3)):
 
                 last_rev += 1
                 new_version = version[:-1] + str(last_rev)
                 shell_exec("./generate-package.bash %s %s %s" % (package_name, new_version, package_size))
-                # Generate some errata
-                all_errata += generate_errata(errata_template, last_rev, package_name, version)
+            # Generate some errata
+            all_errata += generate_errata(errata_template, "1", package_name, new_version)
                 
     # Generate one specific package name you know is always there with multiple revs
     shell_exec("./generate-package.bash acme-package 1.0.1 1")
     shell_exec("./generate-package.bash acme-package 1.0.2 1")
-    all_errata += generate_errata(errata_template, "1.0.1 ", "acme-package", "1.0.2")
+    all_errata += generate_errata(errata_template, "1", "acme-package", "1.0.2")
     shell_exec("./generate-package.bash acme-package 1.1.2 1")
-    all_errata += generate_errata(errata_template, "1.0.2 ", "acme-package", "1.1.2")
+    all_errata += generate_errata(errata_template, "1", "acme-package", "1.1.2")
     
     
     #bad string concats but I'm lazy                

--- a/specfile-template.ini
+++ b/specfile-template.ini
@@ -1,6 +1,6 @@
 Name: %%NAME%%
 Version: %%VERSION%%
-Release: 1.elfake
+Release: 1
 Summary: %{name} package	
 
 Group: Development/Libraries


### PR DESCRIPTION
Removed 'elfake' from package name.
Changed errata's 'Type' and 'Date' fields to be random as well.
If '-m' option is specified, then generate at least 1 new version of package and generate only one errata for the latest version of package.
Corrected putting the package version value for errata in 'updateinfo.xml'.
